### PR TITLE
Support Task-level Resources Requirements

### DIFF
--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -3944,11 +3944,41 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResources(ref common.ReferenceCallback
 							},
 						},
 					},
+					"limits": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+									},
+								},
+							},
+						},
+					},
+					"requests": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResource"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResource", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -70,6 +70,16 @@ type TaskResources struct {
 	// DeclaredPipelineResources to the input PipelineResources required by the Task.
 	// +listType=atomic
 	Outputs []TaskResource `json:"outputs,omitempty"`
+	// Limits describes the maximum amount of compute resources allowed.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+	// +optional
+	Limits v1.ResourceList `json:"limits,omitempty"`
+	// Requests describes the minimum amount of compute resources required.
+	// If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+	// otherwise to an implementation-defined value.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+	// +optional
+	Requests v1.ResourceList `json:"requests,omitempty"`
 }
 
 // TaskResource defines an input or output Resource declared as a requirement

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2223,6 +2223,14 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
+        "limits": {
+          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object",
+          "additionalProperties": {
+            "default": {},
+            "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+          }
+        },
         "outputs": {
           "description": "Outputs holds the mapping from the PipelineResources declared in DeclaredPipelineResources to the input PipelineResources required by the Task.",
           "type": "array",
@@ -2231,6 +2239,14 @@
             "$ref": "#/definitions/v1beta1.TaskResource"
           },
           "x-kubernetes-list-type": "atomic"
+        },
+        "requests": {
+          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object",
+          "additionalProperties": {
+            "default": {},
+            "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+          }
         }
       }
     },

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1589,6 +1589,20 @@ func (in *TaskResources) DeepCopyInto(out *TaskResources) {
 		*out = make([]TaskResource, len(*in))
 		copy(*out, *in)
 	}
+	if in.Limits != nil {
+		in, out := &in.Limits, &out.Limits
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.Requests != nil {
+		in, out := &in.Requests, &out.Requests
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4131,9 +4131,7 @@ status:
 	}
 }
 
-func Test_validateTaskSpecRequestResources_ValidResources(t *testing.T) {
-	ctx := context.Background()
-
+func Test_validateStepLevelResourcesRequirements_validResourcesRequirements(t *testing.T) {
 	tcs := []struct {
 		name     string
 		taskSpec *v1beta1.TaskSpec
@@ -4238,16 +4236,15 @@ func Test_validateTaskSpecRequestResources_ValidResources(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateTaskSpecRequestResources(ctx, tc.taskSpec); err != nil {
-				t.Fatalf("Expected to see error when validating invalid TaskSpec resources but saw none")
+			if err := validateStepLevelResourcesRequirements(tc.taskSpec); err != nil {
+				t.Errorf("Expected no errors when validating valid step-level resources requirements, but got: %v", err)
 			}
 		})
 	}
 
 }
 
-func Test_validateTaskSpecRequestResources_InvalidResources(t *testing.T) {
-	ctx := context.Background()
+func Test_validateStepLevelResourcesRequirements_invalidResourcesRequirements(t *testing.T) {
 	tcs := []struct {
 		name     string
 		taskSpec *v1beta1.TaskSpec
@@ -4294,8 +4291,8 @@ func Test_validateTaskSpecRequestResources_InvalidResources(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateTaskSpecRequestResources(ctx, tc.taskSpec); err == nil {
-				t.Fatalf("Expected to see error when validating invalid TaskSpec resources but saw none")
+			if err := validateStepLevelResourcesRequirements(tc.taskSpec); err == nil {
+				t.Errorf("Expected errors when validating invalid step-level resources requirements, but got none")
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/validate_resources.go
+++ b/pkg/reconciler/taskrun/validate_resources.go
@@ -223,29 +223,85 @@ func ValidateResolvedTaskResources(ctx context.Context, params []v1beta1.Param, 
 	return nil
 }
 
-func validateTaskSpecRequestResources(ctx context.Context, taskSpec *v1beta1.TaskSpec) error {
-	if taskSpec != nil {
-		for _, step := range taskSpec.Steps {
-			for k, request := range step.Resources.Requests {
-				// First validate the limit in step
-				if limit, ok := step.Resources.Limits[k]; ok {
-					if (&limit).Cmp(request) == -1 {
-						return fmt.Errorf("Invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
-					}
-				} else if taskSpec.StepTemplate != nil {
-					// If step doesn't configure the limit, validate the limit in stepTemplate
-					if limit, ok := taskSpec.StepTemplate.Resources.Limits[k]; ok {
-						if (&limit).Cmp(request) == -1 {
-							return fmt.Errorf("Invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
-						}
-					}
+// validateStepLevelResourcesRequirements() validates step-level resources requirements under 'Task.TaskSpec.Step' and 'Task.TaskSpec.StepTemplate'
+func validateStepLevelResourcesRequirements(taskSpec *v1beta1.TaskSpec) error {
+	if !isResourcesRequirementsInStepLevel(taskSpec) {
+		return nil
+	}
 
+	for _, step := range taskSpec.Steps {
+		for key, request := range step.Resources.Requests {
+			// First validate the limit in step
+			if limit, ok := step.Resources.Limits[key]; ok {
+				// Check if limit < request (so out of limit)
+				if (&limit).Cmp(request) == -1 {
+					return fmt.Errorf("invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
+				}
+			} else if taskSpec.StepTemplate != nil {
+				// If step doesn't configure the limit, validate the limit in stepTemplate
+				if limit, ok := taskSpec.StepTemplate.Resources.Limits[key]; ok {
+					if (&limit).Cmp(request) == -1 {
+						return fmt.Errorf("invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
+					}
 				}
 
 			}
 		}
 	}
 
+	return nil
+}
+
+// isResourcesRequirementsInStepLevel() checks if any resources requirements specified under step-level
+func isResourcesRequirementsInStepLevel(taskSpec *v1beta1.TaskSpec) bool {
+	if taskSpec == nil {
+		return false
+	}
+
+	for _, step := range taskSpec.Steps {
+		if step.Resources.Size() > 0 {
+			return true
+		}
+	}
+
+	return taskSpec.StepTemplate != nil && taskSpec.StepTemplate.Resources.Size() > 0
+}
+
+// isResourcesRequirementsInTaskLevel() checks if any resources requirements specified under task-level
+func isResourcesRequirementsInTaskLevel(taskSpec *v1beta1.TaskSpec) bool {
+	if taskSpec == nil || taskSpec.Resources == nil {
+		return false
+	}
+	return taskSpec.Resources.Limits != nil || taskSpec.Resources.Requests != nil
+}
+
+// validateTaskLevelResourcesRequirements() validates task-level resource requirements under 'Task.TaskSpec'
+func validateTaskLevelResourcesRequirements(taskSpec *v1beta1.TaskSpec) error {
+	if !isResourcesRequirementsInTaskLevel(taskSpec) {
+		return nil
+	}
+
+	for key, request := range taskSpec.Resources.Requests {
+		if limit, ok := taskSpec.Resources.Limits[key]; ok {
+			// Check if limit < request (so out of limit)
+			if (&limit).Cmp(request) == -1 {
+				return fmt.Errorf("invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
+			}
+		}
+	}
+
+	return nil
+}
+
+// updateByTaskLevelResourcesRequirements() updates 1st avaliable step with task-level resources requirements
+func updateByTaskLevelResourcesRequirements(taskSpec *v1beta1.TaskSpec) error {
+	if taskSpec == nil || taskSpec.Steps == nil {
+		return fmt.Errorf("no step avaliable to be configured by task-level resources requirements")
+	}
+	for id := range taskSpec.Steps {
+		taskSpec.Steps[id].Resources.Limits = taskSpec.Resources.Limits
+	}
+	taskSpec.Steps[0].Resources.Requests = taskSpec.Resources.Requests
 	return nil
 }
 


### PR DESCRIPTION
Support Task-level Resources Requirements

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
